### PR TITLE
Complex Rule Condition Null Variant ID

### DIFF
--- a/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
+++ b/src/BigCommerce/ResourceModels/Catalog/Product/ComplexRuleConditions.php
@@ -9,6 +9,6 @@ class ComplexRuleConditions extends ResourceModel
     public int $rule_id;
     public int $modifier_id;
     public int $modifier_value_id;
-    public array $variant_id;
+    public ?int $variant_id;
     public int $combination_id;
 }


### PR DESCRIPTION
Allow null values for variant id in complex rule condition.